### PR TITLE
CTC_Wav2vec2 asr model

### DIFF
--- a/01_download_data_model.sh
+++ b/01_download_data_model.sh
@@ -48,7 +48,6 @@ if [ ! -d $check ]; then
 fi
 
 check_data=data/libri_dev_enrolls
-check_model=exp/asv_pre_ecapa
 #Download kaldi format datadir and SpeechBrain pretrained ASV/ASR models
 if [ ! -d $check_data ]; then
     if  [ ! -f data.zip ]; then
@@ -59,13 +58,28 @@ if [ ! -d $check_data ]; then
     unzip data.zip
 fi
 
+check_model=exp/asv_pre_ecapa
 if [ ! -d $check_model ]; then
     if [ ! -f pre_model.zip ]; then
-        echo "Download pretrained ASV & ASR models trained using original train-clean-360..."
+        echo "Download pretrained evaluation models..."
         wget https://github.com/DigitalPhonetics/VoicePAT/releases/download/v2/pre_model.zip
     fi
     echo "Unpacking pretrained evaluation models"
     unzip pre_model.zip
+fi
+
+check_model=exp/asr_pre_ctc_wav2vec2
+if [ ! -d $check_model ]; then
+python3 - <<EOF
+import speechbrain as sb
+
+sb.pretrained.interfaces.Pretrained.from_hparams(
+    source="speechbrain/asr-wav2vec2-librispeech",
+    savedir="$check_model",
+    revision="a9fdfb4",
+    download_only=True
+)
+EOF
 fi
 
 #Download GAN pre-models only if perform GAN anonymization

--- a/02_run.sh
+++ b/02_run.sh
@@ -2,14 +2,12 @@
 
 source env.sh
 
-#generate b2 anonymized audio (libri dev+test set - 25min & libri-360h)
+# Generate b2 anonymized audio (libri dev+test set & libri-360h)
 python run_anonymization_dsp.py --config anon_dsp.yaml
 
-#perform libri dev+test pre evaluation using pretrained ASV/ASR models
-#ASV-8mins, ASR- hours if eval_batchsize=3, ASR- hours if evel_batchsize=2 (default)
+# Perform libri dev+test pre evaluation using pretrained ASV models
 python run_evaluation.py --config eval_pre_from_anon_datadir.yaml
 
-
-#train post ASV using anonymized libri-360 and perform libri dev+test post evaluation
-#ASV training takes 2hours
+# Train post ASV using anonymized libri-360 and perform libri dev+test post evaluation
+# ASV training takes 2hours
 python run_evaluation.py --config eval_post_scratch_from_anon_datadir.yaml 

--- a/configs/eval_pre_from_anon_datadir.yaml
+++ b/configs/eval_pre_from_anon_datadir.yaml
@@ -48,5 +48,5 @@ utility:
 
     evaluation:
       model_dir: !ref <exp_dir>/<utility[asr][model_name]>
-      eval_batchsize: 8 # eval_batchsize(32g)=3 ->9h eval_batchsize=2->12h eval_batchsize(12GB)=1->24h
+      eval_batchsize: 8 # Requires < 12Gib
       results_dir: !ref <exp_dir>/<utility[asr][model_name]>

--- a/configs/eval_pre_from_anon_datadir.yaml
+++ b/configs/eval_pre_from_anon_datadir.yaml
@@ -43,10 +43,11 @@ privacy:
 utility:
   asr:
     backend: speechbrain
-    model_name: asr_pre_ctc_wav2vec2  # name for ASR model
-    model_type: EncoderASR # EncoderDecoderASR or EncoderASR (from speechbrain)
+    model_name: asr_pre_ctc_wav2vec2  # name for ASR model, check 'exp/' dir
 
     evaluation:
+      model_type: EncoderASR # EncoderDecoderASR or EncoderASR (from speechbrain)
+      # hparams_file: transformer_inference.yaml # Check 'model_dir' config yaml file, default to 'hyperparams.yaml'
       model_dir: !ref <exp_dir>/<utility[asr][model_name]>
       eval_batchsize: 8 # Requires < 12Gib
       results_dir: !ref <exp_dir>/<utility[asr][model_name]>

--- a/configs/eval_pre_from_anon_datadir.yaml
+++ b/configs/eval_pre_from_anon_datadir.yaml
@@ -43,9 +43,10 @@ privacy:
 utility:
   asr:
     backend: speechbrain
-    model_name: asr_pre_sb  # name for ASR model
-    
+    model_name: asr_pre_ctc_wav2vec2  # name for ASR model
+    model_type: EncoderASR # EncoderDecoderASR or EncoderASR (from speechbrain)
+
     evaluation:
       model_dir: !ref <exp_dir>/<utility[asr][model_name]>
-      eval_batchsize: 2 # eval_batchsize(32g)=3 ->9h eval_batchsize=2->12h eval_batchsize(12GB)=1->24h
+      eval_batchsize: 8 # eval_batchsize(32g)=3 ->9h eval_batchsize=2->12h eval_batchsize(12GB)=1->24h
       results_dir: !ref <exp_dir>/<utility[asr][model_name]>

--- a/evaluation/utility/asr/speechbrain_asr/inference.py
+++ b/evaluation/utility/asr/speechbrain_asr/inference.py
@@ -42,12 +42,12 @@ class ASRDataset(torch.utils.data.Dataset):
 
 class InferenceSpeechBrainASR:
 
-    def __init__(self, model_path, model_type, device):
+    def __init__(self, model_path, asr_hparams, model_type, device):
         self.device = device
         print(f'Use ASR model for evaluation: {model_path}')
         assert model_type in ["EncoderASR", "EncoderDecoderASR"]
         self.asr_model = getattr(sys.modules[__name__], model_type).from_hparams(source=model_path,
-                                                            hparams_file='hyperparams.yaml',
+                                                            hparams_file=asr_hparams,
                                                             savedir=model_path, run_opts={'device': self.device})
 
     def plain_text_key(self, path):

--- a/evaluation/utility/asr/speechbrain_asr/inference.py
+++ b/evaluation/utility/asr/speechbrain_asr/inference.py
@@ -1,3 +1,4 @@
+import sys
 from utils import save_kaldi_format
 from copy import deepcopy
 
@@ -41,12 +42,18 @@ class ASRDataset(torch.utils.data.Dataset):
 
 class InferenceSpeechBrainASR:
 
-    def __init__(self, model_path, device):
+    def __init__(self, model_path, model_type, device):
         self.device = device
         print(f'Use ASR model for evaluation: {model_path}')
-        self.asr_model = EncoderDecoderASR.from_hparams(source=model_path,
-                                                        hparams_file='transformer_inference.yaml',
-                                                        savedir=model_path, run_opts={'device': self.device})
+        # try:
+        #     self.asr_model = EncoderDecoderASR.from_hparams(source=model_path,
+        #                                                     hparams_file='hyperparams.yaml',
+        #                                                     savedir=model_path, run_opts={'device': self.device})
+        # except:
+        assert model_type in ["EncoderASR", "EncoderDecoderASR"]
+        self.asr_model = getattr(sys.modules[__name__], model_type).from_hparams(source=model_path,
+                                                            hparams_file='hyperparams.yaml',
+                                                            savedir=model_path, run_opts={'device': self.device})
 
     def plain_text_key(self, path):
         tokens = []  # key: token_list

--- a/evaluation/utility/asr/speechbrain_asr/inference.py
+++ b/evaluation/utility/asr/speechbrain_asr/inference.py
@@ -45,11 +45,6 @@ class InferenceSpeechBrainASR:
     def __init__(self, model_path, model_type, device):
         self.device = device
         print(f'Use ASR model for evaluation: {model_path}')
-        # try:
-        #     self.asr_model = EncoderDecoderASR.from_hparams(source=model_path,
-        #                                                     hparams_file='hyperparams.yaml',
-        #                                                     savedir=model_path, run_opts={'device': self.device})
-        # except:
         assert model_type in ["EncoderASR", "EncoderDecoderASR"]
         self.asr_model = getattr(sys.modules[__name__], model_type).from_hparams(source=model_path,
                                                             hparams_file='hyperparams.yaml',

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -206,6 +206,7 @@ if __name__ == '__main__':
             if 'evaluation' in asr_params:
                 asr_eval_params = asr_params['evaluation']
                 model_path = asr_eval_params['model_dir']
+                model_type = asr_params['model_type']
                 asr_model_path = scan_checkpoint(model_path, 'CKPT') or model_path
 
                 if not model_path.exists():
@@ -215,7 +216,7 @@ if __name__ == '__main__':
                 print('Perform ASR evaluation')
                 asr_results = evaluate_asr(eval_datasets=eval_data_asr, eval_data_dir=eval_data_dir,
                                            params=asr_eval_params, model_path=asr_model_path,
-                                           anon_data_suffix=anon_suffix, device=device, backend=backend)
+                                           anon_data_suffix=anon_suffix, device=device, model_type=model_type, backend=backend)
                 results['asr'] = asr_results
                 print("--- ASR evaluation time: %f min ---" % (float(time.time() - start_time) / 60))
 

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s- %(levelname)s - %(message)s')
 
     params = parse_yaml(Path('configs', args.config))
-    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
 
     eval_data_dir = params['eval_data_dir']
     anon_suffix = params['anon_data_suffix']
@@ -184,8 +184,6 @@ if __name__ == '__main__':
             asr_params = params['utility']['asr']
             
             model_name = asr_params['model_name']
-            backend = asr_params['backend'].lower()
-
 
             if 'training' in asr_params:
                 asr_train_params = asr_params['training']
@@ -205,18 +203,15 @@ if __name__ == '__main__':
 
             if 'evaluation' in asr_params:
                 asr_eval_params = asr_params['evaluation']
-                model_path = asr_eval_params['model_dir']
-                model_type = asr_params['model_type']
-                asr_model_path = scan_checkpoint(model_path, 'CKPT') or model_path
-
-                if not model_path.exists():
-                    raise FileNotFoundError(f'ASR model {model_path} does not exist!')
+                asr_eval_params["device"] = device
 
                 start_time = time.time()
                 print('Perform ASR evaluation')
-                asr_results = evaluate_asr(eval_datasets=eval_data_asr, eval_data_dir=eval_data_dir,
-                                           params=asr_eval_params, model_path=asr_model_path,
-                                           anon_data_suffix=anon_suffix, device=device, model_type=model_type, backend=backend)
+                asr_results = evaluate_asr(asr_params['backend'].lower(),
+                                           eval_datasets=eval_data_asr,
+                                           eval_data_dir=eval_data_dir,
+                                           params=asr_eval_params,
+                                           anon_data_suffix=anon_suffix)
                 results['asr'] = asr_results
                 print("--- ASR evaluation time: %f min ---" % (float(time.time() - start_time) / 60))
 


### PR DESCRIPTION
Faster model trained on more data, since we are evaluating asr-utility using an ASR model trained on clear (non-anonymized) data for everything, using such model make more sense as it allow for better utility analysis and the user does not have to train such big model (wav2vec2).
Using a larger model for asr-utility was also one of the recommendation/question that has been made by one of my PhD reviewer. It helps to better evaluate mispronunciation (when the training data is clear and test is anon).
TODO, remove older ASR model  ?
remove older model ASR training scripts ?
```
  dataset split       asr     WER
0   libri   dev  original   1.803
1   libri  test  original   1.844
2   libri   dev      anon   9.230
3   libri  test      anon  11.249
--- ASR evaluation time: 2.139606 min ---

```
GPU memory max requirement 12Gib
