### PR TITLE
feat: add ASRBN pipeline (similar to b1b)

### DIFF
--- a/02_run.sh
+++ b/02_run.sh
@@ -9,7 +9,7 @@ source env.sh
 # Anonymization pipeline
 anon_config=anon_mcadams.yaml
 # anon_config=anon_sttts.yaml
-anon_config=anon_asrbn.yaml
+# anon_config=anon_asrbn.yaml
 
 force_compute=
 # force_compute='--force_compute True'

--- a/02_run.sh
+++ b/02_run.sh
@@ -9,6 +9,7 @@ source env.sh
 # Anonymization pipeline
 anon_config=anon_mcadams.yaml
 # anon_config=anon_sttts.yaml
+anon_config=anon_asrbn.yaml
 
 force_compute=
 # force_compute='--force_compute True'

--- a/anonymization/modules/asrbn/anonymise_dir.py
+++ b/anonymization/modules/asrbn/anonymise_dir.py
@@ -71,7 +71,7 @@ def process_data(dataset_path: Path, anon_level: str, results_dir: Path, setting
     device = settings.get("device", "cpu")
     batch_size = settings.get("batch_size", 4)
     single_spkid = settings.get("single_spkid", "6081")
-    tag_version = settings.get("model_tag_version", "6081") 
+    tag_version = settings.get("model_tag_version", "hifigan_bn_tdnnf_wav2vec2_vq_48_v1") 
 
     copy_data_dir(dataset_path, output_path)
     results_dir = output_path / results_dir

--- a/anonymization/modules/asrbn/anonymise_dir.py
+++ b/anonymization/modules/asrbn/anonymise_dir.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3.0
+# -*- coding: utf-8 -*-
+"""
+@author: Pierre Champion
+Re-implementation of: https://arxiv.org/abs/2308.04455
+some features are missing from the thesis (Speaker F0 norm + F0 quant and other), results will differ.
+"""
+
+import multiprocessing
+from pathlib import Path
+import wave
+from tqdm import tqdm
+
+import torch
+import torchaudio
+import kaldiio
+
+from utils import read_kaldi_format, copy_data_dir, create_clean_dir, setup_logger
+from .utils import float2pcm
+
+logger = setup_logger(__name__)
+
+class Wav(): # for f0 extraction
+    def __init__(self, w):
+        self.wav = w
+
+class Dataset(torch.utils.data.Dataset):
+    def __init__(self, id_wavs, get_f0_func):
+        self.all_wavs = list(id_wavs.values())
+        self.all_keys = list(id_wavs.keys())
+        self.get_f0_func = get_f0_func
+
+    def __len__(self):
+        return len(self.all_wavs)
+
+    def __getitem__(self, index):
+        audio, freq = torchaudio.load(self.all_wavs[index])
+        f0 = self.get_f0_func(Wav(audio))
+        return {"utid": self.all_keys[index],
+                "audio": audio,
+                "f0": f0,
+                "freq": freq}
+
+def collate_fn(item_list):
+    batch_size = len(item_list)
+
+    data_list_audio = [i['audio'] for i in item_list]
+    lengths_tensor_audio = torch.tensor([i.shape[-1] for i in data_list_audio])
+    max_len_audio = torch.max(lengths_tensor_audio).item()
+    output_audio = torch.zeros([batch_size, max_len_audio])
+    for i in range(batch_size):
+        cur = data_list_audio[i]
+        cur_len = data_list_audio[i].shape[-1]
+        output_audio[i, :cur_len] = cur.squeeze()
+
+    data_list_f0 = [i['f0'] for i in item_list]
+    lengths_tensor_f0 = torch.tensor([i.shape[-1] for i in data_list_f0])
+    max_len_f0 = torch.max(lengths_tensor_f0).item()
+    output_f0 = torch.zeros([batch_size, max_len_f0])
+    for i in range(batch_size):
+        cur = data_list_f0[i]
+        cur_len = data_list_f0[i].shape[-1]
+        output_f0[i, :cur_len] = cur.squeeze()
+
+    utids = [i['utid'] for i in item_list]
+    freqs = [i['freq'] for i in item_list]
+    return output_audio, output_f0, lengths_tensor_audio, utids, freqs
+
+def process_data(dataset_path: Path, anon_level: str, results_dir: Path, settings: dict, force_compute: bool):
+    output_path = Path(str(dataset_path) + settings['anon_suffix'])
+    device = settings.get("device", "cpu")
+    batch_size = settings.get("batch_size", 4)
+    single_spkid = settings.get("single_spkid", "6081")
+    tag_version = settings.get("model_tag_version", "6081") 
+
+    copy_data_dir(dataset_path, output_path)
+    results_dir = output_path / results_dir
+    create_clean_dir(results_dir, force=force_compute)
+
+    wav_scp = dataset_path / 'wav.scp'
+    path_wav_scp_out = output_path / 'wav.scp'
+
+    model = torch.hub.load("deep-privacy/SA-toolkit", "anonymization",
+                           tag_version=tag_version,
+                           trust_repo=True)
+    model.to(device)
+    model.eval()
+
+    @torch.no_grad()
+    def process_wav(utid, freq, audio, f0, original_len):
+
+        freq = freq[0] # assume all freq = in same batch (and so dataset)
+        audio = audio.to(device)
+
+        # anonymize
+        model.set_f0(f0.to(device)) # CPU extracted in by Dataloader (num_workers)
+        wav_conv = model.convert(audio, target=single_spkid)
+        wav_conv = wav_conv.cpu()
+
+        def parallel_write():
+            for i in range(wav_conv.shape[0]):
+                wav = wav_conv[i]
+                if len(wav.shape) > 1:
+                    wav = wav[:, :original_len[i]]
+                signal = float2pcm(wav.numpy())
+                # write to buffer
+                u = utid[i]
+                output_file = results_dir / f'{u}.wav'
+                with output_file.open('wb') as file:
+                    with wave.open(file, 'wb') as stream:
+                        stream.setframerate(freq)
+                        stream.setnchannels(1)
+                        stream.setsampwidth(2)
+                        stream.writeframes(signal)
+        p = multiprocessing.Process(target=parallel_write, args=())
+        p.start()
+
+        return p
+
+    wavs = read_kaldi_format(wav_scp)
+    nj = multiprocessing.cpu_count()
+    nj = min(nj, 18)
+    p = None
+
+    with open(path_wav_scp_out, 'wt', encoding='utf-8') as writer:
+        filtered_wavs = {}
+        for u, file in wavs.items():
+            output_file = results_dir / f'{u}.wav'
+            if output_file.exists() and not force_compute:
+                logger.debug(f'File {output_file} already exists')
+                writer.writelines(f"{u} {output_file}\n")
+            else:
+                filtered_wavs[u] = file
+
+        data_loader = torch.utils.data.DataLoader(Dataset(filtered_wavs, model.get_f0), batch_size=batch_size, num_workers=nj, collate_fn=collate_fn)
+        for audio, f0, original_len, utid, freq in tqdm(data_loader):
+            p = process_wav(utid, freq, audio, f0, original_len)
+            for u in utid:
+                output_file = results_dir / f'{u}.wav'
+                writer.writelines(f"{u} {output_file}\n")
+            torch.cuda.empty_cache()
+    # wait for last p to write the anonymized audios
+    if p:
+        p.join()
+    logger.info('Done')

--- a/anonymization/modules/asrbn/anonymise_dir.py
+++ b/anonymization/modules/asrbn/anonymise_dir.py
@@ -12,10 +12,9 @@ import wave
 from tqdm import tqdm
 
 import torch
-import torchaudio
 import kaldiio
 
-from utils import read_kaldi_format, copy_data_dir, create_clean_dir, setup_logger
+from utils import read_kaldi_format, copy_data_dir, create_clean_dir, setup_logger, load_wav_from_scp
 from .utils import float2pcm
 
 logger = setup_logger(__name__)
@@ -34,7 +33,7 @@ class Dataset(torch.utils.data.Dataset):
         return len(self.all_wavs)
 
     def __getitem__(self, index):
-        audio, freq = torchaudio.load(self.all_wavs[index])
+        audio, freq = load_wav_from_scp(self.all_wavs[index])
         f0 = self.get_f0_func(Wav(audio))
         return {"utid": self.all_keys[index],
                 "audio": audio,

--- a/anonymization/modules/asrbn/utils.py
+++ b/anonymization/modules/asrbn/utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+def float2pcm(sig, dtype='int16'):
+    """
+    https://gist.github.com/HudsonHuang/fbdf8e9af7993fe2a91620d3fb86a182
+    """
+    sig = np.asarray(sig)
+    if sig.dtype.kind != 'f':
+        raise TypeError("'sig' must be a float array")
+    dtype = np.dtype(dtype)
+    if dtype.kind not in 'iu':
+        raise TypeError("'dtype' must be an integer type")
+    i = np.iinfo(dtype)
+    abs_max = 2 ** (i.bits - 1)
+    offset = i.min + abs_max
+    return (sig * abs_max + offset).clip(i.min, i.max).astype(dtype)

--- a/anonymization/pipelines/asrbn/__init__.py
+++ b/anonymization/pipelines/asrbn/__init__.py
@@ -1,0 +1,2 @@
+from .asrbn_pipeline import ASRBNPipeline
+

--- a/anonymization/pipelines/asrbn/asrbn_pipeline.py
+++ b/anonymization/pipelines/asrbn/asrbn_pipeline.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3.0
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+from ...modules.asrbn.anonymise_dir import process_data
+
+from utils import setup_logger
+
+logger = setup_logger(__name__)
+
+class ASRBNPipeline:
+    def __init__(self, config: dict, force_compute: bool = False, devices: list = [0]):
+        """
+        Instantiates a ASRBNVQPipeline.
+
+        This pipeline consists of:
+                  ->      F0 (yaapt: no transformation)    --\
+            input ->    ASR-BN (vq stransformed or not)  --->  Speech synthesis (hifigan)
+                                                                          ^
+                                                                          |
+                                                                  Target speaker (one-hot)
+
+        Args:
+            config (dict): a configuration dictionary, e.g., see anon_ims_sttts_pc.yaml
+            force_compute (bool): if True, forces re-computation of
+                all steps. otherwise uses saved results.
+            devices (list): a list of torch-interpretable devices
+        """
+        self.config = config
+        self.force_compute = force_compute
+        self.modules_config = config['modules']
+
+    def run_anonymization_pipeline(self, datasets):
+        # anonymize each dataset
+        for i, (dataset_name, dataset_path) in enumerate(datasets.items()):
+            if 'anon_level_spk' in self.modules_config and dataset_name in self.modules_config['anon_level_spk']:
+                raise ValueError("spk not implemented")
+                anon_level = "spk"
+            if 'anon_level_utt' in self.modules_config and dataset_name in self.modules_config['anon_level_utt']:
+                raise ValueError("utt not implemented")
+                anon_level = "utt"
+            if 'anon_level_single' in self.modules_config and dataset_name in self.modules_config['anon_level_single']:
+                anon_level = "single"
+            print(f'{i + 1}/{len(datasets)}: ASR-BN processing of "{dataset_name}" at anon_level "{anon_level}"...')
+            process_data(dataset_path=dataset_path,
+                         anon_level=anon_level,
+                         results_dir=self.config['results_dir'],
+                         settings=self.modules_config,
+                         force_compute=self.force_compute,
+                         )

--- a/anonymization/pipelines/asrbn/requirements.txt
+++ b/anonymization/pipelines/asrbn/requirements.txt
@@ -1,0 +1,5 @@
+torch
+torchaudio
+soundfile
+numpy
+configargparse

--- a/configs/anon_asrbn.yaml
+++ b/configs/anon_asrbn.yaml
@@ -1,0 +1,30 @@
+data_dir: data
+results_dir: anon_wav # output example ./data/IEMOCAP_asrbn-vq/anon_wav
+
+pipeline: asrbn
+anon_suffix: !ref _<pipeline>
+
+datasets:
+  - name: IEMOCAP_dev
+    data: IEMOCAP_dev
+  - name: IEMOCAP_test
+    data: IEMOCAP_test
+  - name: libri_dev
+    data: libri_dev
+    enrolls: [_enrolls]
+    trials: [_trials_f, _trials_m]
+  - name: libri_test
+    data: libri_test
+    enrolls: [_enrolls]
+    trials: [_trials_f, _trials_m]
+  - name: train-clean-360
+    data: train-clean-360
+
+modules:
+  anon_suffix: !ref <anon_suffix>
+  anon_level_single: [IEMOCAP_test, IEMOCAP_dev, libri_dev, libri_test, train-clean-360]
+  single_spkid: "6081"
+  # Other models can be found here: https://github.com/deep-privacy/SA-toolkit/releases
+  model_tag_version: "hifigan_bn_tdnnf_wav2vec2_vq_48_v1"
+  device: "cuda"
+  batch_size: 8 # works with GPU < 12Gib

--- a/configs/anon_asrbn.yaml
+++ b/configs/anon_asrbn.yaml
@@ -2,7 +2,7 @@ data_dir: data
 results_dir: anon_wav # output example ./data/IEMOCAP_asrbn-vq/anon_wav
 
 pipeline: asrbn
-anon_suffix: !ref _<pipeline>
+anon_suffix: !ref _<pipeline>_<modules[model_tag_version]>
 
 datasets:
   - name: IEMOCAP_dev
@@ -25,6 +25,9 @@ modules:
   anon_level_single: [IEMOCAP_test, IEMOCAP_dev, libri_dev, libri_test, train-clean-360]
   single_spkid: "6081"
   # Other models can be found here: https://github.com/deep-privacy/SA-toolkit/releases
+  # model_tag_version: "hifigan_bn_tdnnf_600h_aug_v1"
+  # model_tag_version: "hifigan_bn_tdnnf_600h_vq_48_v1"
+  # model_tag_version: "hifigan_bn_tdnnf_wav2vec2_100h_aug_v1"
   model_tag_version: "hifigan_bn_tdnnf_wav2vec2_vq_48_v1"
   device: "cuda"
   batch_size: 8 # works with GPU < 12Gib

--- a/run_anonymization.py
+++ b/run_anonymization.py
@@ -31,6 +31,9 @@ if __name__ == '__main__':
         subprocess.run(['bash', 'anonymization/pipelines/sttts/install.sh'])
         check_dependencies('anonymization/pipelines/sttts/requirements.txt')
         from anonymization.pipelines.sttts import STTTSPipeline as pipeline
+    elif config['pipeline'] == "asrbn":
+        check_dependencies('anonymization/pipelines/asrbn/requirements.txt')
+        from anonymization.pipelines.asrbn import ASRBNPipeline as pipeline
     else:
         raise ValueError(f"Pipeline {config['pipeline']} not defined/imported")
 


### PR DESCRIPTION
RE-Implementation from my Thesis of a ASRBN-Wav2vec2-(finetuned left-biphone)-VQ (48 codebooks).
Mid results in term of privacy (30% of EER with `eval_post_asrbn`) good asr utility on librispeech (`4.407`), surprisingly bad for emotion (36% UAR), and as bad as expected on non-clean speech asr utility (IEMOCAP).

A big advantage of this pipeline is that it provide marginally better results than the mcadams one, while being reasonably fast to compute, **anonymizing all datasets took 3hours!** (yes IEMOCAP and train-clean-360 included.)

Below the results, and logs: for the model: `hifigan_bn_tdnnf_wav2vec2_vq_48_v1`, I will add other models later (no wav2vec2 and no VQ).