### PR TITLE
feat: use a generic load_wav_from_scp for loading scp entry.

### DIFF
--- a/anonymization/modules/mcadams/anonymise_dir_mcadams_rand_seed.py
+++ b/anonymization/modules/mcadams/anonymise_dir_mcadams_rand_seed.py
@@ -18,10 +18,9 @@ import scipy.signal
 import shutil
 import wave
 
-import kaldiio
 from pathlib import Path
 from tqdm import tqdm
-from utils import read_kaldi_format, copy_data_dir, create_clean_dir, setup_logger
+from utils import read_kaldi_format, copy_data_dir, create_clean_dir, setup_logger, load_wav_from_scp
 
 multiprocessing.set_start_method('spawn', force=True)
 
@@ -66,12 +65,12 @@ def process_data(dataset_path: Path, anon_level: str, results_dir: Path, setting
     path_wav_scp_out = output_path / 'wav.scp'
 
     # get the number of utterances in the dataset
-    wavs = read_kaldi_format(wav_scp)
-    N = len(wavs)
+    reader = read_kaldi_format(wav_scp)
+    N = len(reader)
 
     if anon_level == 'spk':
         # sample per speaker
-        seeds = map(lambda x: hash_textstring(utt2spk[x]), wavs.keys())
+        seeds = map(lambda x: hash_textstring(utt2spk[x]), reader.keys())
         rngs = map(np.random.default_rng, seeds)
         mcadams_coeffs = map(lambda x: x.uniform(settings['mc_coeff_min'], settings['mc_coeff_max']), rngs)
     else:
@@ -84,7 +83,6 @@ def process_data(dataset_path: Path, anon_level: str, results_dir: Path, setting
         nj = settings['nj']
 
     settings["force_compute"] = force_compute
-    reader = kaldiio.load_scp(str(wav_scp))
     fn = functools.partial(process_wav, settings=settings, reader=reader, output_path=str(results_dir))
     with multiprocessing.Pool(processes=nj) as pool:
         scp_entries = pool.starmap(fn, tqdm(zip(mcadams_coeffs, reader.keys()), total=N), chunksize=len(reader)//(nj*10))
@@ -99,7 +97,9 @@ def process_wav(mcadams, utid, reader, settings, output_path):
         logger.debug(f'File {output_file} already exists')
         return f'{utid} {output_file}\n'
 
-    (freq, samples) = reader[utid]
+    file = reader[utid]
+    samples, freq = load_wav_from_scp(file)
+    samples = samples.squeeze(0).numpy()
 
     # convert from int16 to float
     if samples.dtype == np.int16:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
-from .data_io import read_kaldi_format, save_kaldi_format, parse_yaml, save_yaml, write_table
+from .data_io import read_kaldi_format, save_kaldi_format, parse_yaml, save_yaml, write_table, load_wav_from_scp
 from .path_management import (create_clean_dir, remove_contents_in_dir, get_datasets,
                               scan_checkpoint, copy_data_dir)
 from .prepare_results_in_kaldi_format import combine_asr_data

--- a/utils/data_io.py
+++ b/utils/data_io.py
@@ -4,6 +4,11 @@ import json
 import pandas as pd
 import logging
 
+import torchaudio
+import io
+import os
+import subprocess
+
 logger = logging.getLogger(__name__)
 
 def read_kaldi_format(filename, return_as_dict=True, values_as_string=False):
@@ -28,6 +33,36 @@ def read_kaldi_format(filename, return_as_dict=True, values_as_string=False):
         return key_list, value_list
     return dict(zip(key_list, value_list))
 
+
+def load_wav_from_scp(wav, frame_offset: int = 0,  num_frames: int = -1):
+    """Reads a wav.scp entry like kaldi with embeded unix command
+    and returns a pytorch tensor like it was open with torchaudio.load()
+    (within some tolerance due to numerical precision))
+
+    Args:
+        wav: a list containing the scp entry
+
+    Returns:
+        out_feats: torch.tensor array dtype float32 (default)
+    """
+    if isinstance(wav, list):
+        wav = " ".join(str(x) for x in wav)
+    if wav.strip().endswith("|"):
+        devnull = open(os.devnull, "w")
+        try:
+            wav_read_process = subprocess.Popen(
+                wav.strip()[:-1], stdout=subprocess.PIPE, shell=True, stderr=devnull
+            )
+            sample, sr = torchaudio.backend.soundfile_backend.load(
+                io.BytesIO(wav_read_process.communicate()[0]),
+                frame_offset=frame_offset, num_frames=num_frames
+            )
+        except Exception as e:
+            raise IOError("Error processing wav file: {}\n{}".format(wav, e))
+    else:
+        sample, sr = torchaudio.backend.soundfile_backend.load(wav, frame_offset=frame_offset, num_frames=num_frames)
+
+    return sample, sr
 
 def read_table(filename, names, sep=' ', dtype=None):
     if isinstance(dtype, list):
@@ -85,7 +120,7 @@ def _transform_paths(yaml_dict):
     path_tags = {'_dir', '_file', '_path', '_folder'}
     for key, value in yaml_dict.items():
         if value is None:
-            continue 
+            continue
         if isinstance(value, dict):
             yaml_dict[key] = _transform_paths(value)
         elif any(tag in key for tag in path_tags) and value is not None:


### PR DESCRIPTION
works with `uttid /path/test.flac` (kaldiio does not work)  
works with `uttid flac -c -d -s /path/test.flac` (torchaudio.load does not work)