### PR TITLE
Fix merge results

### DIFF
--- a/02_run.sh
+++ b/02_run.sh
@@ -35,12 +35,10 @@ python run_evaluation.py --config eval_pre.yaml --overwrite "${eval_overwrite}"
 python run_evaluation.py --config eval_post.yaml --overwrite "${eval_overwrite}"
 
 
-results_summary_path_orig=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('./configs/eval_pre.yaml'); print(load_hyperpyyaml(f, None).get('results_summary_path', ''))")
+# Merge results
+results_summary_path_orig=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('./configs/eval_pre.yaml'); print(load_hyperpyyaml(f, ${eval_overwrite}).get('results_summary_path', ''))")
+results_summary_path_anon=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('./configs/eval_post.yaml'); print(load_hyperpyyaml(f, ${eval_overwrite}).get('results_summary_path', ''))")
 
-results_summary_path_anon=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('./configs/eval_post.yaml'); print(load_hyperpyyaml(f, None).get('results_summary_path', ''))")
-
-results_exp=exp/results_summary
+results_exp=$(dirname $results_summary_path_anon)
 mkdir -p ${results_exp}
 { cat "${results_summary_path_orig}"; echo; cat "${results_summary_path_anon}"; } > "${results_exp}/result_for_rank${anon_suffix}"
-
-

--- a/02_run.sh
+++ b/02_run.sh
@@ -39,6 +39,6 @@ python run_evaluation.py --config eval_post.yaml --overwrite "${eval_overwrite}"
 results_summary_path_orig=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('./configs/eval_pre.yaml'); print(load_hyperpyyaml(f, ${eval_overwrite}).get('results_summary_path', ''))")
 results_summary_path_anon=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('./configs/eval_post.yaml'); print(load_hyperpyyaml(f, ${eval_overwrite}).get('results_summary_path', ''))")
 
-results_exp=$(dirname $results_summary_path_anon)
+results_exp=exp/results_summary
 mkdir -p ${results_exp}
 { cat "${results_summary_path_orig}"; echo; cat "${results_summary_path_anon}"; } > "${results_exp}/result_for_rank${anon_suffix}"


### PR DESCRIPTION
The `eval_overwrite` unsure that when the anonymization config file is changed, the evaluation is performed on this new anonymization system, rather than on `_mcadams` (if eval_*.yaml are not modified).