### PR TITLE
Add training script for phone aligner

### DIFF
--- a/anonymization/modules/sttts/prosody/pretrain_aligner.py
+++ b/anonymization/modules/sttts/prosody/pretrain_aligner.py
@@ -1,0 +1,119 @@
+# the aligner is only pretrained because it is finetuned on every utterance on-the-fly
+import argparse
+import os
+import sys
+import random
+from pathlib import Path
+import torch
+from torch.utils.data import ConcatDataset
+
+sys.path.insert(0, str(Path('../../../..').resolve().absolute()))
+from anonymization.modules.sttts.tts.IMSToucan.TrainingInterfaces.Text_to_Spectrogram.AutoAligner.autoaligner_train_loop import train_loop as train_aligner
+from anonymization.modules.sttts.tts.IMSToucan.Utility.corpus_preparation import prepare_aligner_corpus
+
+
+def limit_to_n(path_to_transcript_dict, n=30000):
+    limited_dict = dict()
+    if len(path_to_transcript_dict.keys()) > n:
+        for key in random.sample(list(path_to_transcript_dict.keys()), n):
+            limited_dict[key] = path_to_transcript_dict[key]
+        return limited_dict
+    else:
+        return path_to_transcript_dict
+
+
+def build_path_to_transcript_dict_libritts_clean(train_data_path):
+    # this is fitted to the LibriTTS data structure, for a different data set, you need to adjust this function
+    path_to_transcript = dict()
+    for speaker in os.listdir(train_data_path):
+        for chapter in os.listdir(os.path.join(train_data_path, speaker)):
+            for file in os.listdir(os.path.join(train_data_path, speaker, chapter)):
+                if file.endswith("normalized.txt"):
+                    with open(os.path.join(train_data_path, speaker, chapter, file), 'r', encoding='utf8') as tf:
+                        transcript = tf.read()
+                    wav_file = file.split(".")[0] + ".wav"
+                    path_to_transcript[os.path.join(train_data_path, speaker, chapter, wav_file)] = transcript
+    return limit_to_n(path_to_transcript)
+
+
+def run(train_data_path, gpu_id, resume_checkpoint, finetune, model_dir, resume):
+    if gpu_id == "cpu":
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        device = torch.device("cpu")
+
+    else:
+        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+        os.environ["CUDA_VISIBLE_DEVICES"] = "{}".format(gpu_id)
+        device = torch.device("cuda")
+
+    torch.manual_seed(131714)
+    random.seed(131714)
+    torch.random.manual_seed(131714)
+
+    print("Preparing")
+
+    train_set = prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_libritts_clean(train_data_path),
+                                       corpus_dir=os.path.join("Corpora", "libri_clean"),
+                                       lang="en",
+                                       device=device)
+
+    if model_dir is not None:
+        save_dir = model_dir
+    else:
+        save_dir = os.path.join("Models", "Aligner")
+    os.makedirs(save_dir, exist_ok=True)
+    save_dir_aligner = save_dir + "/aligner"
+    os.makedirs(save_dir_aligner, exist_ok=True)
+
+    train_aligner(train_dataset=train_set,
+                  device=device,
+                  save_directory=save_dir,
+                  steps=500000,
+                  batch_size=32,
+                  path_to_checkpoint=resume_checkpoint,
+                  fine_tune=finetune,
+                  debug_img_path=save_dir_aligner,
+                  resume=resume)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='IMS Speech Synthesis Toolkit - Pretrain Aligner')
+
+    parser.add_argument('--train_data_path',
+                        type=str,
+                        help="Path to train data.",
+                        default="corpora/LibriTTS/clean")
+
+    parser.add_argument('--gpu_id',
+                        type=str,
+                        help="Which GPU to run on. If not specified runs on CPU, but other than for integration tests that doesn't make much sense.",
+                        default="cpu")
+
+    parser.add_argument('--resume_checkpoint',
+                        type=str,
+                        help="Path to checkpoint to resume from.",
+                        default=None)
+
+    parser.add_argument('--resume',
+                        action="store_true",
+                        help="Automatically load the highest checkpoint and continue from there.",
+                        default=False)
+
+    parser.add_argument('--finetune',
+                        action="store_true",
+                        help="Whether to fine-tune from the specified checkpoint.",
+                        default=False)
+
+    parser.add_argument('--model_save_dir',
+                        type=str,
+                        help="Directory where the checkpoints should be saved to.",
+                        default=None)
+
+    args = parser.parse_args()
+
+    run(train_data_path=args.train_data_path,
+        gpu_id=args.gpu_id,
+        resume_checkpoint=args.resume_checkpoint,
+        resume=args.resume,
+        finetune=args.finetune,
+        model_dir=args.model_save_dir)

--- a/anonymization/pipelines/sttts/readme_sttts_pipeline.md
+++ b/anonymization/pipelines/sttts/readme_sttts_pipeline.md
@@ -56,3 +56,5 @@ This pipeline can be run by specifying the [anon_sttts.yaml](../../../configs/an
 Please be aware that, depending on the size of your dataset, the anonymization can take some time.
 Intermediate representations of all modules are saved to disk.
 If the pipeline is run a second time, the intermediate representations will be loaded by default, and only recomputed if explicitly specified in order to reduce the run time.
+Because of the long run time of the full anonymization pipeline, we provide the intermediate representations for text transcriptions, prosody extraction and speaker embedding extraction for the LibriSpeech data. 
+When running the pipeline, these representations are automatically downloaded and their computation is skipped during anonymization.

--- a/anonymization/pipelines/sttts/readme_training.md
+++ b/anonymization/pipelines/sttts/readme_training.md
@@ -40,7 +40,6 @@ Per default, the training will be performed for LibriTTS which will be downloade
 It will be stored to a *downloads* inside the recipe that needs to be created before execution.
 If you want to change this to a different location, or already have LibriTTS installed and skip to download it again, you need to change the *LibriTTS* value in [db.sh](../../modules/sttts/text/recognition/asr_training/asr/db.sh).
 
-
 # Speech Synthesis Models
 The speech synthesis module consists of two models: a TTS based on FastSpeech2 and a HiFiGAN vocoder. 
 These models need to be trained separately.
@@ -61,6 +60,20 @@ In the script, the original structure of LibriTTS or LibriSpeech (the separation
 If you use a different dataset or structure, you need to change the `build_path_to_transcript_dict_libritts_clean()` in `train_tts_model.py` and `get_file_list_libritts` in `train_vocoder_model.py` to match your data.
 Inspirations for that can be found in the [official IMS Toucan repository](https://github.com/DigitalPhonetics/IMS-Toucan/blob/ToucanTTS/Utility/path_to_transcript_dicts.py). 
 
+# Phone Alignment for Prosody Extraction
+Prosodic information in form of pitch and energy is extracted for each phone, together with the phone duration.
+For this, we need the alignment between the transcribed phones and the input waveform. 
+Thus, we train an aligner that provides us these alignments.
+The aligner is an ASR model, but much simpler and less accurate than the one we use for the phonetic transcriptions.
+Because it is more lightweight, we can finetune the model online for each utterance before generating the alignment which improves the quality of the phone alignment.
+More information about this method can be found [in this paper](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=10022433).
+
+As for the speech synthesis model, the aligner is implemented in the IMS Toucan toolkit. 
+Pretraining of the aligner model is therefore similar to the training steps for both synthesis models.
+The [pretrain_aligner.py](../../modules/sttts/prosody/pretrain_aligner.py) script can be found in [anonymization/modules/sttts/prosody](../../modules/sttts/prosody) and run by:
+```angular2html
+python pretrain_aligner.py --train_data_path <path_to_train_data> --gpu_id <gpu_id>
+```
 
 # Speaker Embeddings GAN
 The model to generate artificial speaker embeddings for anonymization is a Wasserstein Generative Adversarial Network. 


### PR DESCRIPTION
This PR adds the training script for the phone aligner in the STTTS prosody extraction. It also updates the readmes for the STTTS pipeline to include information about the aligner training and the precomputed intermediate results.

The changes are standalone and do not affect any other scripts in the repository. I verified that the training script is functional, no additional testing is necessary