### PR TITLE
feat: submission script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.tar.gz
 .done-*
 .micromamba/
 .micromamba
@@ -149,3 +150,5 @@ subset_data_dir.sh
 .idea
 anonymization/modules/nac/coqui_tts/
 .install-hash*
+utils/dropbox_uploader.sh
+.vpc-dropbox_uploader

--- a/03_upload_submission.sh
+++ b/03_upload_submission.sh
@@ -45,7 +45,7 @@ echo "OAUTH_APP_SECRET=$VPC_DROPBOX_SECRET" >> .vpc-dropbox_uploader
 echo "OAUTH_REFRESH_TOKEN=$VPC_DROPBOX_REFRESHTOKEN" >> .vpc-dropbox_uploader
 
 if test "$anon_suffix" = "test"; then
-  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload LICENSE LICENSE.txt
+  ./utils/dropbox_uploader.sh -d -f .vpc-dropbox_uploader upload LICENSE LICENSE.txt 2> /dev/null || (cat /tmp/du_resp_debug && exit 1)
   ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader delete LICENSE.txt
   echo " -- Tested ended --"
   exit 0

--- a/03_upload_submission.sh
+++ b/03_upload_submission.sh
@@ -5,6 +5,7 @@
 # Fresh install with "rm .done-upload-tool"
 
 set -e
+nj=$(nproc)
 
 source ./env.sh
 
@@ -29,6 +30,7 @@ if [ ! -f $mark ]; then
   echo " == Installing tools to upload dataset =="
   curl -s "https://raw.githubusercontent.com/andreafabrizi/Dropbox-Uploader/master/dropbox_uploader.sh" -o ./utils/dropbox_uploader.sh
   chmod +x ./utils/dropbox_uploader.sh
+  micromamba install -y -c conda-forge pigz pv tar
   touch $mark
 fi
 
@@ -44,25 +46,25 @@ echo "OAUTH_REFRESH_TOKEN=$VPC_DROPBOX_REFRESHTOKEN" >> .vpc-dropbox_uploader
 
 if test "$anon_suffix" = "test"; then
   ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload LICENSE LICENSE.txt
-  echo "Tested ended"
+  echo " -- Tested ended --"
   exit 0
 fi
 
 if [[ "$anon_suffix" == *yaml ]]; then
-  echo "Config detected, reading 'anon_suffix'"
+  echo " -- Config detected, reading 'anon_suffix' --"
   anon_suffix=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('${anon_suffix}'); print(load_hyperpyyaml(f, None).get('anon_suffix', ''))")
 fi
 
-echo "Anon suffix used to upload the submission: $anon_suffix"
-sleep 1
+echo " -- Anon suffix used to upload the submission: '${anon_suffix}' --"
+
+stuff_to_zip=""
 
 results_exp=exp/results_summary
 file=${results_exp}/result_for_rank${anon_suffix}
 [ ! -f $file ] && echo "File $file does not exist." && exit 1
 file=${results_exp}/result_for_submission${anon_suffix}.zip
 [ ! -f $file ] && echo "File $file does not exist." && exit 1
-./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload ${results_exp}/result_for_rank${anon_suffix} results_summary${anon_suffix}/result_for_rank${anon_suffix}.txt
-./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload ${results_exp}/result_for_submission${anon_suffix}.zip results_summary${anon_suffix}/result_for_submission${anon_suffix}.zip
+stuff_to_zip="${stuff_to_zip} ${results_exp}/result_for_rank${anon_suffix} ${results_exp}/result_for_submission${anon_suffix}.zip"
 
 tuples=(
   # Data path                            Rough estimate of the data/wavs size (Should be higher)
@@ -86,11 +88,11 @@ for ((i=0; i<length; i+=2)); do
   if [ "$dir_size" -lt "$threshold" ]; then
     echo "Directory '$dir' size ($dir_size bytes) is not greater than $threshold bytes. The wavs must be in this folder for submission." && exit 1
   fi
+  stuff_to_zip="${stuff_to_zip} ${dir}"
 done
 
-for ((i=0; i<length; i+=2)); do
-  dir=${tuples[i]}
-  zip "$(basename $dir).zip" -r ${dir}
-  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload "$(basename $dir).zip" "data${anon_suffix}/$(basename $dir).zip"
-  \rm "$(basename $dir).zip"
-done
+echo " -- Creating the submission archive before upload (using: $nj threads) --"
+tar --use-compress-program="pigz --best --processes $nj -f | pv -rb" -cf submission${anon_suffix}.tar.gz $stuff_to_zip
+
+echo " -- Uploading the archive ($(du -sbh submission${anon_suffix}.tar.gz | cut -f1)) --"
+./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload submission${anon_suffix}.tar.gz "submission${anon_suffix}_$(date +'%Y-%m-%d_%T').tar.gz"

--- a/03_upload_submission.sh
+++ b/03_upload_submission.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Usage: VPC_DROPBOX_KEY=XXX VPC_DROPBOX_SECRET=YYY VPC_DROPBOX_REFRESHTOKEN=ZZZ ./03_upload_submission.sh $anon_data_suffix
+
+# Fresh install with "rm .done-upload-tool"
+
+set -e
+
+source ./env.sh
+
+##################################################
+## Provided environment variables (or modify here)
+##################################################
+# VPC_DROPBOX_KEY=
+# VPC_DROPBOX_SECRET=
+# VPC_DROPBOX_REFRESHTOKEN=
+##################################################
+
+# Select the anonymization suffix
+if [ -n "$1" ]; then
+  anon_suffix=$1
+else
+  echo "Provide the anon_data_suffix for the submission."
+  exit 1
+fi
+
+mark=.done-upload-tool
+if [ ! -f $mark ]; then
+  echo " == Installing tools to upload dataset =="
+  curl -s "https://raw.githubusercontent.com/andreafabrizi/Dropbox-Uploader/master/dropbox_uploader.sh" -o ./utils/dropbox_uploader.sh
+  chmod +x ./utils/dropbox_uploader.sh
+  touch $mark
+fi
+
+if [[ $VPC_DROPBOX_KEY = "" || $VPC_DROPBOX_SECRET = "" || $VPC_DROPBOX_REFRESHTOKEN = "" ]]; then
+    echo -ne "Error loading VPC_DROPBOX_* variables...\n"
+    exit 1
+fi
+
+echo "CONFIGFILE_VERSION=2.0" > .vpc-dropbox_uploader
+echo "OAUTH_APP_KEY=$VPC_DROPBOX_KEY" >> .vpc-dropbox_uploader
+echo "OAUTH_APP_SECRET=$VPC_DROPBOX_SECRET" >> .vpc-dropbox_uploader
+echo "OAUTH_REFRESH_TOKEN=$VPC_DROPBOX_REFRESHTOKEN" >> .vpc-dropbox_uploader
+
+if test "$anon_suffix" = "test"; then
+  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload LICENSE LICENSE.txt
+  echo "Tested ended"
+  exit 0
+fi
+
+if [[ "$anon_suffix" == *yaml ]]; then
+  echo "Config detected, reading 'anon_suffix'"
+  anon_suffix=$(python3 -c "from hyperpyyaml import load_hyperpyyaml; f = open('${anon_suffix}'); print(load_hyperpyyaml(f, None).get('anon_suffix', ''))")
+fi
+
+echo "Anon suffix used to upload the submission: $anon_suffix"
+sleep 1
+
+results_exp=exp/results_summary
+file=${results_exp}/result_for_rank${anon_suffix}
+[ ! -f $file ] && echo "File $file does not exist." && exit 1
+file=${results_exp}/result_for_submission${anon_suffix}.zip
+[ ! -f $file ] && echo "File $file does not exist." && exit 1
+./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload ${results_exp}/result_for_rank${anon_suffix} results_summary${anon_suffix}/result_for_rank${anon_suffix}.txt
+./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload ${results_exp}/result_for_submission${anon_suffix}.zip results_summary${anon_suffix}/result_for_submission${anon_suffix}.zip
+
+tuples=(
+  # Data path                            Rough estimate of the data/wavs size (Should be higher)
+  data/libri_dev_enrolls${anon_suffix}   71101617
+  data/libri_dev_trials_m${anon_suffix}  210210523
+  data/libri_dev_trials_f${anon_suffix}  214121749
+  data/libri_test_enrolls${anon_suffix}  85776535
+  data/libri_test_trials_m${anon_suffix} 206095756
+  data/libri_test_trials_f${anon_suffix} 189792733
+  data/IEMOCAP_dev${anon_suffix}         408732347
+  data/IEMOCAP_test${anon_suffix}        378653727
+  data/train-clean-360${anon_suffix}     40930724008
+)
+
+length=${#tuples[@]}
+for ((i=0; i<length; i+=2)); do
+  dir=${tuples[i]}
+  [ ! -d $dir ] && echo "Directory $file does not exist." && exit 1
+  threshold=${tuples[i+1]}
+  dir_size=$(du -sb "$dir" | cut -f1)
+  if [ "$dir_size" -lt "$threshold" ]; then
+    echo "Directory '$dir' size ($dir_size bytes) is not greater than $threshold bytes. The wavs must be in this folder for submission." && exit 1
+  fi
+done
+
+for ((i=0; i<length; i+=2)); do
+  dir=${tuples[i]}
+  zip "$(basename $dir).zip" -r ${dir}
+  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload "$(basename $dir).zip" "data${anon_suffix}/$(basename $dir).zip"
+  \rm "$(basename $dir).zip"
+done

--- a/03_upload_submission.sh
+++ b/03_upload_submission.sh
@@ -46,6 +46,7 @@ echo "OAUTH_REFRESH_TOKEN=$VPC_DROPBOX_REFRESHTOKEN" >> .vpc-dropbox_uploader
 
 if test "$anon_suffix" = "test"; then
   ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload LICENSE LICENSE.txt
+  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader delete LICENSE.txt
   echo " -- Tested ended --"
   exit 0
 fi

--- a/03_upload_submission.sh
+++ b/03_upload_submission.sh
@@ -4,6 +4,9 @@
 
 # Fresh install with "rm .done-upload-tool"
 
+# Create the upload API keys for the many participents:
+# team_suff=name; ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader_team_$team_suff info && source .vpc-dropbox_uploader_team_$team_suff && VPC_DROPBOX_KEY=$OAUTH_APP_KEY VPC_DROPBOX_SECRET=$OAUTH_APP_SECRET VPC_DROPBOX_REFRESHTOKEN=$OAUTH_REFRESH_TOKEN VPC_TEAM=$team_suff ./03_upload_submission.sh test && echo "\n\nAPI upload ready for team $team_suff:\n----\nVPC_DROPBOX_KEY=$OAUTH_APP_KEY VPC_DROPBOX_SECRET=$OAUTH_APP_SECRET VPC_DROPBOX_REFRESHTOKEN=$OAUTH_REFRESH_TOKEN VPC_TEAM=$team_suff ./03_upload_submission.sh \$anon_data_suffix\n----"
+
 set -e
 nj=$(nproc)
 
@@ -45,8 +48,8 @@ echo "OAUTH_APP_SECRET=$VPC_DROPBOX_SECRET" >> .vpc-dropbox_uploader
 echo "OAUTH_REFRESH_TOKEN=$VPC_DROPBOX_REFRESHTOKEN" >> .vpc-dropbox_uploader
 
 if test "$anon_suffix" = "test"; then
-  ./utils/dropbox_uploader.sh -d -f .vpc-dropbox_uploader upload LICENSE LICENSE.txt 2> /dev/null || (cat /tmp/du_resp_debug && exit 1)
-  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader delete LICENSE.txt
+  ./utils/dropbox_uploader.sh -d -f .vpc-dropbox_uploader upload LICENSE ${VPC_TEAM}_LICENSE.txt 2> /dev/null || (cat /tmp/du_resp_debug && exit 1)
+  ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader delete ${VPC_TEAM}_LICENSE.txt
   echo " -- Tested ended --"
   exit 0
 fi

--- a/03_upload_submission.sh
+++ b/03_upload_submission.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: VPC_DROPBOX_KEY=XXX VPC_DROPBOX_SECRET=YYY VPC_DROPBOX_REFRESHTOKEN=ZZZ ./03_upload_submission.sh $anon_data_suffix
+# Usage: VPC_DROPBOX_KEY=XXX VPC_DROPBOX_SECRET=YYY VPC_DROPBOX_REFRESHTOKEN=ZZZ VPC_TEAM=TEAM_NAME ./03_upload_submission.sh $anon_data_suffix
 
 # Fresh install with "rm .done-upload-tool"
 
@@ -34,8 +34,8 @@ if [ ! -f $mark ]; then
   touch $mark
 fi
 
-if [[ $VPC_DROPBOX_KEY = "" || $VPC_DROPBOX_SECRET = "" || $VPC_DROPBOX_REFRESHTOKEN = "" ]]; then
-    echo -ne "Error loading VPC_DROPBOX_* variables...\n"
+if [[ $VPC_DROPBOX_KEY = "" || $VPC_DROPBOX_SECRET = "" || $VPC_DROPBOX_REFRESHTOKEN = "" || $VPC_TEAM = "" ]]; then
+    echo -ne "Error loading VPC_* variables...\n"
     exit 1
 fi
 
@@ -96,4 +96,4 @@ echo " -- Creating the submission archive before upload (using: $nj threads) --"
 tar --use-compress-program="pigz --best --processes $nj -f | pv -rb" -cf submission${anon_suffix}.tar.gz $stuff_to_zip
 
 echo " -- Uploading the archive ($(du -sbh submission${anon_suffix}.tar.gz | cut -f1)) --"
-./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload submission${anon_suffix}.tar.gz "submission${anon_suffix}_$(date +'%Y-%m-%d_%T').tar.gz"
+./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader upload submission${anon_suffix}.tar.gz "submission_${VPC_TEAM}${anon_suffix}_$(date +'%Y-%m-%d_%T').tar.gz"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Please visit the [challenge website](https://www.voiceprivacychallenge.org/) for
 The anonymization and evaluation scripts should have generated the files and the directories with the explained format of `$anon_data_suffix` suffix.  
 For data submission, the following command submit everything given a `$anon_data_suffix` argument:
 ```
-VPC_DROPBOX_KEY=XXX VPC_DROPBOX_SECRET=YYY VPC_DROPBOX_REFRESHTOKEN=ZZZ ./03_upload_submission.sh $anon_data_suffix
+VPC_DROPBOX_KEY=XXX VPC_DROPBOX_SECRET=YYY VPC_DROPBOX_REFRESHTOKEN=ZZZ VPC_TEAM=TEAM_NAME ./03_upload_submission.sh $anon_data_suffix
 ```
-`VPC_DROPBOX_KEY`, `VPC_DROPBOX_SECRET` and `VPC_DROPBOX_REFRESHTOKEN` are sent individually to each team upon receiving their system description.  
+`VPC_DROPBOX_KEY`, `VPC_DROPBOX_SECRET`, `VPC_DROPBOX_REFRESHTOKEN`, and `VPC_TEAM=TEAM_NAME` are sent individually to each team upon receiving their system description.  
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Please visit the [challenge website](https://www.voiceprivacychallenge.org/) for more information about the Challenge.
 
+## Data submission
+The anonymization and evaluation scripts should have generated the files and the directories with the explained format of `$anon_data_suffix` suffix.  
+For data submission, the following command submit everything given a `$anon_data_suffix` argument:
+```
+VPC_DROPBOX_KEY=XXX VPC_DROPBOX_SECRET=YYY VPC_DROPBOX_REFRESHTOKEN=ZZZ ./03_upload_submission.sh $anon_data_suffix
+```
+`VPC_DROPBOX_KEY`, `VPC_DROPBOX_SECRET` and `VPC_DROPBOX_REFRESHTOKEN` are sent individually to each team upon receiving their system description.  
 
 ## Install
 


### PR DESCRIPTION
Submission script to share the wavs and results files.

To setup the keys for the participants, please follow this semi-automated procedure, where `team_suff=1` is incremented for each dropbox APP (and so participants)
```sh
team_suff=1; ./utils/dropbox_uploader.sh -f .vpc-dropbox_uploader_team_$team_suff info && source .vpc-dropbox_uploader_team_$team_suff && VPC_DROPBOX_KEY=$OAUTH_APP_KEY VPC_DROPBOX_SECRET=$OAUTH_APP_SECRET VPC_DROPBOX_REFRESHTOKEN=$OAUTH_REFRESH_TOKEN VPC_TEAM=$team_suff ./03_upload_submission.sh test && echo "\n\nAPI upload ready for team $team_suff:\n----\nVPC_DROPBOX_KEY=$OAUTH_APP_KEY VPC_DROPBOX_SECRET=$OAUTH_APP_SECRET VPC_DROPBOX_REFRESHTOKEN=$OAUTH_REFRESH_TOKEN VPC_TEAM=$team_suff ./03_upload_submission.sh \$anon_data_suffix\n----"
```